### PR TITLE
Accept onWarning callback as a parameter

### DIFF
--- a/.changeset/loud-hairs-travel.md
+++ b/.changeset/loud-hairs-travel.md
@@ -1,0 +1,5 @@
+---
+"@n1ru4l/graphql-public-schema-filter": minor
+---
+
+accept an onWarning callback as parameter to the buildPublicSchema function

--- a/src/public-schema-filter.spec.ts
+++ b/src/public-schema-filter.spec.ts
@@ -88,6 +88,27 @@ it("can be called", () => {
   );
 });
 
+it("uses the onWarning callback when provided", () => {
+  const source = /* GraphQL */ `
+    type User {
+      id: ID!
+      login: String!
+    }
+
+    type Query {
+      me: User @public
+    }
+  `;
+
+  const schema = buildSchema(source);
+  
+  const onWarning = jest.fn();
+  lib.buildPublicSchema({ schema, onWarning });
+
+  expect(onWarning).toHaveBeenCalled();
+
+});
+
 it("does not expose the public directive", () => {
   const source = /* GraphQL */ `
     type User {


### PR DESCRIPTION
Accepts onWarning as parameter. MR born out of a [previous one](https://github.com/n1ru4l/graphql-public-schema-filter/pull/170).