### PR TITLE
The AST node won't get fixed unless a field mapper is specified

### DIFF
--- a/.changeset/smart-brooms-think.md
+++ b/.changeset/smart-brooms-think.md
@@ -1,0 +1,5 @@
+---
+"@n1ru4l/graphql-public-schema-filter": patch
+---
+
+fixed bug where the ast node was left unchanged after filtering the schema

--- a/src/public-schema-filter.ts
+++ b/src/public-schema-filter.ts
@@ -11,6 +11,7 @@ import {
   DirectiveNode,
   GraphQLFieldConfigArgumentMap,
   isNonNullType,
+  GraphQLFieldConfig,
 } from "graphql";
 import { MapperKind, mapSchema } from "@graphql-tools/utils";
 import { getWrappedType } from "./get-wrapped-type";
@@ -265,6 +266,9 @@ export const buildPublicSchema = (
       }
       config.fields = newFields;
       return new GraphQLObjectType(config);
+    },
+    [MapperKind.OBJECT_FIELD]: (fieldConfig) => {
+      return fieldConfig;
     },
     [MapperKind.INPUT_OBJECT_TYPE]: (objectType) => {
       const config = objectType.toConfig();


### PR DESCRIPTION
The mapSchema function from @graphql-tools/utils function doesn't rewire the astNode in the GraphQLSchema object unless a field mapper is specified. This leads to errors when printing the schema to string.